### PR TITLE
Revert "chore(deps): update dependency eventlet to v0.31.0"

### DIFF
--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,6 +1,6 @@
 PyMySQL==1.0.2
 PyYAML==5.4.1
-eventlet==0.31.0
+eventlet==0.30.3
 gevent==21.1.2
 gunicorn==20.1.0
 mysqlclient==2.0.3


### PR DESCRIPTION
This reverts commit 413601a187faa2c11ab8bc4b17d967fd2f99a95f.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>