### PR TITLE
Use eventlet 0.30.2

### DIFF
--- a/files/requirements.txt
+++ b/files/requirements.txt
@@ -1,6 +1,6 @@
 PyMySQL==1.0.2
 PyYAML==5.4.1
-eventlet==0.31.0
+eventlet==0.30.2
 gevent==21.1.2
 gunicorn==20.1.0
 mysqlclient==2.0.3


### PR DESCRIPTION
Reason:

Error: class uri 'eventlet' invalid or not found:

[Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/gunicorn/util.py", line 99, in load_class
    mod = importlib.import_module('.'.join(components))
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 855, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/usr/local/lib/python3.9/site-packages/gunicorn/workers/geventlet.py", line 20, in <module>
    from eventlet.wsgi import ALREADY_HANDLED as EVENTLET_ALREADY_HANDLED
ImportError: cannot import name 'ALREADY_HANDLED' from 'eventlet.wsgi' (/usr/local/lib/python3.9/site-packages/eventlet/wsgi.py)
]

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>