### PR TITLE
Install libmariadb3 (missing in pypy base image)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
       curl \
       gcc \
       libffi-dev \
+      libmariadb3 \
       libmariadbclient-dev \
       libssl-dev \
       libyaml-dev \


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>